### PR TITLE
refactor: 검색 컴포넌트의 placeholder props로 분리

### DIFF
--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -6,13 +6,13 @@ import { IoSearchSharp } from "react-icons/io5";
  * 문제의 제목이나 내용을 입력할 수 있는 검색 창과 아이콘을 포함한 컴포넌트
  * @returns {JSX.Element} SearchBar 컴포넌트
  */
-const SearchBar = (): JSX.Element => {
+const SearchBar = ({ placeholder }: { placeholder: string }): JSX.Element => {
     return (
         <div className={style.container}>
             <input
                 className={style.searchBar}
                 type="text"
-                placeholder="문제의 제목이나 내용을 입력하세요"
+                placeholder={placeholder}
             />
             <IoSearchSharp className={style.searchIcon} />
         </div>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -19,7 +19,7 @@ const PageHome = () => {
             <Banner />
             <div className={style.problemContainer}>
                 <Column className={style.problemLeft}>
-                    <SearchBar />
+                    <SearchBar placeholder="문제의 제목이나 내용을 입력하세요" />
                     <Row style={{ gap: '10px' }}>
                         <Selector options={OptionsLevel} onChange={() => {}} styles={{ minWidth: '130px'}} />
                         <Selector options={OptionsLanguage} onChange={() => {}} styles={{ minWidth: '180px'}} />


### PR DESCRIPTION
수정 내용
- 메인 페이지 SearchBar placeholder를 `문제의 제목이나 내용을 입력하세요`로 설정